### PR TITLE
fix content-security-policy error

### DIFF
--- a/tools/forge/forge.config.js
+++ b/tools/forge/forge.config.js
@@ -49,6 +49,8 @@ module.exports = {
       // process and support for multiple renderers.
       '@electron-forge/plugin-webpack',
       {
+        // fix content-security-policy error when image or video src isn't same origin
+        devContentSecurityPolicy: "",
         // Ports
         port: 3000, // Webpack Dev Server port
         loggerPort: 9000, // Logger port


### PR DESCRIPTION
if use different origin in video or image src props in env of webpack-devServer, the dev tools will error, this is because content-security-policy, add devContentSecurityPolicy to fix iit;
(such as domain of devServer is localhose, but src is "https:google.com/xxx")